### PR TITLE
Fix broken install snippet on docs pages

### DIFF
--- a/mintlify-docs/guides/js/single-page-apps.mdx
+++ b/mintlify-docs/guides/js/single-page-apps.mdx
@@ -29,12 +29,11 @@ If you prefer not to use npm, add the script tag to your `index.html`:
 
 ```html
 <script>
-!function(d,w){var t='YOUR_ACCOUNT_TOKEN',c='chmln',i=d.createElement('script');
-i.src='https://fast.chameleon.io/messo/'+t+'/messo.min.js';
-i.async=1;d.head.appendChild(i);w[c]=w[c]||function(){(w[c].q=w[c].q||[]).push(arguments)};
-}(document,window);
+!function(d,w){var t="YOUR_ACCOUNT_TOKEN",c="chmln",i=d.createElement("script");if(w[c]||(w[c]={}),!w[c].root){w[c].accountToken=t,w[c].location=w.location.href.toString(),w[c].now=new Date,w[c].fastUrl="https://fast.chameleon.io/";var m="identify alias track clear set show on off custom help _data".split(" ");for(var s=0;s<m.length;s++){!function(){var t=w[c][m[s]+"_a"]=[];w[c][m[s]]=function(){t.push(arguments);};}();}i.src=w[c].fastUrl+"messo/"+t+"/messo.min.js",i.async=!0,d.head.appendChild(i);}}(document,window);
 </script>
 ```
+
+> For the most up-to-date, pre-filled version of this snippet, copy it from your [Install page](https://app.chameleon.io/install).
 
 ---
 

--- a/mintlify-docs/quickstart.mdx
+++ b/mintlify-docs/quickstart.mdx
@@ -44,10 +44,7 @@ chmln.init('YOUR_ACCOUNT_TOKEN');
 
 ```html
 <script>
-!function(d,w){var t='YOUR_ACCOUNT_TOKEN',c='chmln',i=d.createElement('script');
-i.src='https://fast.chameleon.io/messo/'+t+'/messo.min.js';
-i.async=1;d.head.appendChild(i);w[c]=w[c]||function(){(w[c].q=w[c].q||[]).push(arguments)};
-}(document,window);
+!function(d,w){var t="YOUR_ACCOUNT_TOKEN",c="chmln",i=d.createElement("script");if(w[c]||(w[c]={}),!w[c].root){w[c].accountToken=t,w[c].location=w.location.href.toString(),w[c].now=new Date,w[c].fastUrl="https://fast.chameleon.io/";var m="identify alias track clear set show on off custom help _data".split(" ");for(var s=0;s<m.length;s++){!function(){var t=w[c][m[s]+"_a"]=[];w[c][m[s]]=function(){t.push(arguments);};}();}i.src=w[c].fastUrl+"messo/"+t+"/messo.min.js",i.async=!0,d.head.appendChild(i);}}(document,window);
 </script>
 ```
 


### PR DESCRIPTION
## Summary

The `<script>` snippets on `quickstart.mdx` and `guides/js/single-page-apps.mdx` were missing the per-method placeholder arrays (`identify_a`, `track_a`, etc.) that `messo.min.js` expects. On load, `messo.min.js` reads `r.identify_a.length` (see `snippet.js/index.js:112`) and throws:

```
Uncaught TypeError: can't access property "length", r.identify_a is undefined
```

…before the customer ever calls `identify()`. Replaced with the same loader the Dashboard generates (`dashboard/src/components/setup/snippet/Snippet.jsx`), which pre-creates the `*_a` queue arrays for every public API method (`identify`, `alias`, `track`, `clear`, `set`, `show`, `on`, `off`, `custom`, `help`, `_data`).

**Context:** Renowned (prospect) hit this and had to hand-roll the full stub to get past it — Slack thread [here](https://trychameleon.slack.com/archives/C02KPQ91G3C/p1776694027710229).

## Test plan

- [ ] Paste the new snippet into a blank HTML file with a valid account token, load in a browser, confirm no console error on load.
- [ ] Confirm `window.chmln.identify(...)` queues and dispatches correctly once the loader finishes.
- [ ] `mintlify dev` renders both pages without regressions.